### PR TITLE
Move mensagens traduzidas para os arquivos HAML e adiciona traduções …

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
-name: The Crystal Programming Language
-description: A compiled language with Ruby like syntax and type inference
-url: http://crystal-lang.org
+name: A Linguagem de Programação Crystal
+description: Uma linguagem compilada com sintaxe parecida com Ruby e inferência de tipos
+url: http://br.crystal-lang.org
 logo: /images/crystal-h.png
 defaults:
   -

--- a/_includes/_haml/footer.haml
+++ b/_includes/_haml/footer.haml
@@ -1,7 +1,7 @@
 %footer
   %a{:href => "http://pages.github.com", :target => "_blank"}
-    %span Published with
+    %span Publicado com
     %img{:src => '/images/github_pages.png', width: 146, height: 34}
   %a{:href => "http://www.manas.com.ar", :target => "_blank"}
-    %span Sponsored by
+    %span Patrocinado por
     %img{:src => '/images/manas.png', width: 100, height: 34}

--- a/_includes/_haml/header.haml
+++ b/_includes/_haml/header.haml
@@ -3,7 +3,7 @@
     %canvas#logo-canvas{width: 108 * 2, height: 108 * 2, style: "cursor:move"}
     %a{:href => "/"}
       %img{:src => "/images/crystal_logo.png", width: 199, height: 56}
-  #logo-text The Programming Language
+  #logo-text A Linguagem de Programação
   %nav
     %ul.menu
       %li
@@ -18,4 +18,3 @@
         %a{:href => "/api", :title => "API", :target => "_blank"}
           %i.ic.download
           %div API
-

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,7 +5,7 @@
       <img height='56' src='/images/crystal_logo.png' width='199'>
     </a>
   </div>
-  <div id='logo-text'>The Programming Language</div>
+  <div id='logo-text'>A Linguagem de Programação</div>
   <nav>
     <ul class='menu'>
       <li>

--- a/_layouts/_haml/default.haml
+++ b/_layouts/_haml/default.haml
@@ -12,8 +12,8 @@
     #fund
       .inner
         .badge
-          %a.text{:href => "https://www.bountysource.com/teams/crystal-lang/fundraisers/702-crystal-language", :target => "_blank"} Fund Crystal and help it become production-ready!
-          %a.text{:href => "/sponsors"} Meet our sponsors
+          %a.text{:href => "https://www.bountysource.com/teams/crystal-lang/fundraisers/702-crystal-language", :target => "_blank"} Financie a linguagem Crystal e ajude-a a se tornar pronta para produção!
+          %a.text{:href => "/sponsors"} Conheça nossos patrocinadores
           %a{:href => "https://www.bountysource.com/teams/crystal-lang/fundraisers/702-crystal-language", :target => "_blank"}
             %img{:src => "https://api.bountysource.com/badge/team?team_id=89730&style=raised"}
     .wrapper

--- a/_layouts/_haml/post.haml
+++ b/_layouts/_haml/post.haml
@@ -3,7 +3,7 @@ layout: default
 \---
 %section
   %h1 {{ page.title }}
-  %p.meta {{ page.date | date_to_string }} by {{ page.author }}
+  %p.meta {{ page.date | date_to_string }} por {{ page.author }}
   {{ content }}
 
   #disqus_thread

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <section>
   <h1>{{ page.title }}</h1>
-  <p class='meta'>{{ page.date | date_to_string }} by {{ page.author }}</p>
+  <p class='meta'>{{ page.date | date_to_string }} por {{ page.author }}</p>
   {{ content }}
   <div id='disqus_thread'></div>
   <script>

--- a/index.haml
+++ b/index.haml
@@ -1,16 +1,16 @@
 \---
 \---
 %section
-  %h1 Language Goals
+  %h1 Metas da Linguagem
   %ul.goals
-    %li Have a syntax similar to Ruby (but compatibility with it is not a goal)
-    %li Statically type-checked but without having to specify the type of variables or method arguments.
-    %li Be able to call C code by writing bindings to it in Crystal.
-    %li Have compile-time evaluation and generation of code, to avoid boilerplate code.
-    %li Compile to efficient native code.
+    %li Ter uma sintaxe similar à Ruby (porém compatibilidade com a mesma não é uma meta)
+    %li Checagem estática de tipos mas sem ter de especificar o tipo das variáveis ou argumentos de método.
+    %li Poder chamar código em C escrevendo bindings ao mesmo em Crystal.
+    %li Ter avaliação em tempo de compilação e geração de código, para evitar código repetido.
+    %li Compilar em código nativo eficiente.
 
 %section
-  %h1 How it looks
+  %h1 Como se parece
   .code_section
     {% include sample_code.md %}
 
@@ -18,19 +18,19 @@
   %h1 Status
   %p
     %ul.goals
-      %li The project is in alpha stage: we are still tweaking the language and standard library.
-      %li The compiler is written in Crystal.
+      %li O projeto está em estágio alfa: ainda estamos ajustando a linguagem e a biblioteca padrão.
+      %li O compilador é escrito em Crystal.
 
 %section
-  %h1 Community
+  %h1 Comunidade
   %p
-    Post a question or suggest something in our
+    Poste uma questão ou sugira algo em nosso
     %i.ip.group
-    %a{href: "https://groups.google.com/forum/?fromgroups#!forum/crystal-lang", target: "_blank"} Google Group
-    or join our IRC channel #crystal-lang at irc.freenode.net
+    %a{href: "https://groups.google.com/forum/?fromgroups#!forum/crystal-lang", target: "_blank"} Grupo do Google
+    ou junte-se ao nosso canal IRC #crystal-lang em irc.freenode.net
 
 %section
-  %h1 Entries from our blog
+  %h1 Postagens em nosso blog
   .blog_roll
     {% for post in site.posts %}
     %article

--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 ---
 ---
 <section>
-  <h1>Metas da linguagem</h1>
+  <h1>Metas da Linguagem</h1>
   <ul class='goals'>
     <li>Ter uma sintaxe similar à Ruby (porém compatibilidade com a mesma não é uma meta)</li>
     <li>Checagem estática de tipos mas sem ter de especificar o tipo das variáveis ou argumentos de método.</li>
     <li>Poder chamar código em C escrevendo bindings ao mesmo em Crystal.</li>
     <li>Ter avaliação em tempo de compilação e geração de código, para evitar código repetido.</li>
-    <li>Compile to efficient native code.</li>
+    <li>Compilar em código nativo eficiente.</li>
   </ul>
 </section>
 <section>
@@ -30,7 +30,7 @@
   <p>
     Poste uma questão ou sugira algo em nosso
     <i class='ip group'></i>
-    <a href='https://groups.google.com/forum/?fromgroups#!forum/crystal-lang' target='_blank'>grupo do Google</a>
+    <a href='https://groups.google.com/forum/?fromgroups#!forum/crystal-lang' target='_blank'>Grupo do Google</a>
     ou junte-se ao nosso canal IRC #crystal-lang em irc.freenode.net
   </p>
 </section>


### PR DESCRIPTION
Os arquivos `.html` do site (exceto documentação, API, etc.) são gerados com o comando `rake haml`, então eu movi as traduções pros arquivos `.haml` e adicionei algumas mensagens que faltavam.
